### PR TITLE
fix: widen dependency ranges to accept v2.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "jasmine": "^3.99.0",
     "lighthouse": "^12.1.0",
     "lint-staged": "^13.2.1",
-    "qcobjects-cli": "^2.4.65",
+    "qcobjects-cli": ">=2.4.65 <3.0.0",
     "qcobjects-tsconfig": "^2.4.10",
     "semistandard": "^16.0.1",
     "typescript": "^5.0.4"
@@ -119,10 +119,10 @@
     "grunt-contrib-jasmine": "^4.0.0",
     "npm-watch": "^0.11.0",
     "nyc": "^15.1.0",
-    "qcobjects": "^2.4.95",
+    "qcobjects": ">=2.4.95 <3.0.0",
     "qcobjects-admin": "^1.0.0",
     "qcobjects-command-publish-static": "^1.0.4",
-    "qcobjects-sdk": "^2.4.64"
+    "qcobjects-sdk": ">=2.4.64 <3.0.0"
   },
   "engines": {
     "npm": ">=8",


### PR DESCRIPTION
Changes  ranges to  so npm can resolve both v2.4 and v2.5 releases without ERESOLVE.

Fixes #45

Part of the chain fixing QCObjects/qcobjects-cli#8